### PR TITLE
Add notebook with Harmony workflow.

### DIFF
--- a/notebooks/project_result_harmony.ipynb
+++ b/notebooks/project_result_harmony.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Harmony workflow\n",
+    "\n",
+    "This notebook replicates the workflow to retrieve subsetted ATL06 (v006) data using Harmony (via [harmony-py](https://github.com/nasa/harmony-py)) to fulfil the subsetting request).\n",
+    "\n",
+    "## Required packages:\n",
+    "\n",
+    "* notebook\n",
+    "* pyproj\n",
+    "* numpy\n",
+    "* harmony-py\n",
+    "\n",
+    "## Other requirements:\n",
+    "\n",
+    "A `.netrc` file with credentials for Earthdata Login (production).\n",
+    "\n",
+    "## Optional - install packages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: notebook in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (7.4.5)\n",
+      "Requirement already satisfied: harmony-py in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (1.3.0)\n",
+      "Collecting pyproj\n",
+      "  Downloading pyproj-3.7.2-cp312-cp312-macosx_14_0_arm64.whl.metadata (31 kB)\n",
+      "Requirement already satisfied: numpy in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (2.3.2)\n",
+      "Requirement already satisfied: jupyter-server<3,>=2.4.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from notebook) (2.16.0)\n",
+      "Requirement already satisfied: jupyterlab-server<3,>=2.27.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from notebook) (2.27.3)\n",
+      "Requirement already satisfied: jupyterlab<4.5,>=4.4.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from notebook) (4.4.6)\n",
+      "Requirement already satisfied: notebook-shim<0.3,>=0.2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from notebook) (0.2.4)\n",
+      "Requirement already satisfied: tornado>=6.2.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from notebook) (6.5.2)\n",
+      "Requirement already satisfied: anyio>=3.1.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (4.10.0)\n",
+      "Requirement already satisfied: argon2-cffi>=21.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (25.1.0)\n",
+      "Requirement already satisfied: jinja2>=3.0.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (3.1.6)\n",
+      "Requirement already satisfied: jupyter-client>=7.4.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (8.6.3)\n",
+      "Requirement already satisfied: jupyter-core!=5.0.*,>=4.12 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (5.8.1)\n",
+      "Requirement already satisfied: jupyter-events>=0.11.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (0.12.0)\n",
+      "Requirement already satisfied: jupyter-server-terminals>=0.4.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (0.5.3)\n",
+      "Requirement already satisfied: nbconvert>=6.4.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (7.16.6)\n",
+      "Requirement already satisfied: nbformat>=5.3.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (5.10.4)\n",
+      "Requirement already satisfied: overrides>=5.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (7.7.0)\n",
+      "Requirement already satisfied: packaging>=22.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (25.0)\n",
+      "Requirement already satisfied: prometheus-client>=0.9 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (0.22.1)\n",
+      "Requirement already satisfied: pyzmq>=24 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (27.0.1)\n",
+      "Requirement already satisfied: send2trash>=1.8.2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (1.8.3)\n",
+      "Requirement already satisfied: terminado>=0.8.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (0.18.1)\n",
+      "Requirement already satisfied: traitlets>=5.6.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (5.14.3)\n",
+      "Requirement already satisfied: websocket-client>=1.7 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-server<3,>=2.4.0->notebook) (1.8.0)\n",
+      "Requirement already satisfied: async-lru>=1.0.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab<4.5,>=4.4.5->notebook) (2.0.5)\n",
+      "Requirement already satisfied: httpx<1,>=0.25.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab<4.5,>=4.4.5->notebook) (0.28.1)\n",
+      "Requirement already satisfied: ipykernel!=6.30.0,>=6.5.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab<4.5,>=4.4.5->notebook) (6.30.1)\n",
+      "Requirement already satisfied: jupyter-lsp>=2.0.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab<4.5,>=4.4.5->notebook) (2.2.6)\n",
+      "Requirement already satisfied: setuptools>=41.1.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab<4.5,>=4.4.5->notebook) (80.9.0)\n",
+      "Requirement already satisfied: certifi in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from httpx<1,>=0.25.0->jupyterlab<4.5,>=4.4.5->notebook) (2025.8.3)\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from httpx<1,>=0.25.0->jupyterlab<4.5,>=4.4.5->notebook) (1.0.9)\n",
+      "Requirement already satisfied: idna in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from httpx<1,>=0.25.0->jupyterlab<4.5,>=4.4.5->notebook) (3.10)\n",
+      "Requirement already satisfied: h11>=0.16 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.25.0->jupyterlab<4.5,>=4.4.5->notebook) (0.16.0)\n",
+      "Requirement already satisfied: babel>=2.10 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab-server<3,>=2.27.1->notebook) (2.17.0)\n",
+      "Requirement already satisfied: json5>=0.9.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab-server<3,>=2.27.1->notebook) (0.12.1)\n",
+      "Requirement already satisfied: jsonschema>=4.18.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab-server<3,>=2.27.1->notebook) (4.25.1)\n",
+      "Requirement already satisfied: requests>=2.31 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyterlab-server<3,>=2.27.1->notebook) (2.32.5)\n",
+      "Requirement already satisfied: python-dateutil~=2.9 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (2.9.0.post0)\n",
+      "Requirement already satisfied: python-dotenv~=0.20.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (0.20.0)\n",
+      "Requirement already satisfied: progressbar2~=4.2.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (4.2.0)\n",
+      "Requirement already satisfied: sphinxcontrib-napoleon~=0.7 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (0.7)\n",
+      "Requirement already satisfied: curlify~=2.2.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (2.2.1)\n",
+      "Requirement already satisfied: shapely~=2.0.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from harmony-py) (2.0.7)\n",
+      "Requirement already satisfied: python-utils>=3.0.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from progressbar2~=4.2.0->harmony-py) (3.9.1)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from python-dateutil~=2.9->harmony-py) (1.17.0)\n",
+      "Requirement already satisfied: charset_normalizer<4,>=2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from requests>=2.31->jupyterlab-server<3,>=2.27.1->notebook) (3.4.3)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from requests>=2.31->jupyterlab-server<3,>=2.27.1->notebook) (2.5.0)\n",
+      "Requirement already satisfied: pockets>=0.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from sphinxcontrib-napoleon~=0.7->harmony-py) (0.9.1)\n",
+      "Requirement already satisfied: sniffio>=1.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from anyio>=3.1.0->jupyter-server<3,>=2.4.0->notebook) (1.3.1)\n",
+      "Requirement already satisfied: typing_extensions>=4.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from anyio>=3.1.0->jupyter-server<3,>=2.4.0->notebook) (4.14.1)\n",
+      "Requirement already satisfied: argon2-cffi-bindings in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->notebook) (25.1.0)\n",
+      "Requirement already satisfied: appnope>=0.1.2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.1.4)\n",
+      "Requirement already satisfied: comm>=0.1.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.2.3)\n",
+      "Requirement already satisfied: debugpy>=1.6.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (1.8.16)\n",
+      "Requirement already satisfied: ipython>=7.23.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (9.4.0)\n",
+      "Requirement already satisfied: matplotlib-inline>=0.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.1.7)\n",
+      "Requirement already satisfied: nest-asyncio>=1.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (1.6.0)\n",
+      "Requirement already satisfied: psutil>=5.7 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (7.0.0)\n",
+      "Requirement already satisfied: decorator in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (5.2.1)\n",
+      "Requirement already satisfied: ipython-pygments-lexers in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (1.1.1)\n",
+      "Requirement already satisfied: jedi>=0.16 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.19.2)\n",
+      "Requirement already satisfied: pexpect>4.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (4.9.0)\n",
+      "Requirement already satisfied: prompt_toolkit<3.1.0,>=3.0.41 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (3.0.51)\n",
+      "Requirement already satisfied: pygments>=2.4.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (2.19.2)\n",
+      "Requirement already satisfied: stack_data in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.6.3)\n",
+      "Requirement already satisfied: wcwidth in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from prompt_toolkit<3.1.0,>=3.0.41->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.2.13)\n",
+      "Requirement already satisfied: parso<0.9.0,>=0.8.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jedi>=0.16->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.8.4)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jinja2>=3.0.3->jupyter-server<3,>=2.4.0->notebook) (3.0.2)\n",
+      "Requirement already satisfied: attrs>=22.2.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->notebook) (25.3.0)\n",
+      "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->notebook) (2025.4.1)\n",
+      "Requirement already satisfied: referencing>=0.28.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->notebook) (0.36.2)\n",
+      "Requirement already satisfied: rpds-py>=0.7.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema>=4.18.0->jupyterlab-server<3,>=2.27.1->notebook) (0.27.0)\n",
+      "Requirement already satisfied: platformdirs>=2.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-core!=5.0.*,>=4.12->jupyter-server<3,>=2.4.0->notebook) (4.3.8)\n",
+      "Requirement already satisfied: python-json-logger>=2.0.4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (3.3.0)\n",
+      "Requirement already satisfied: pyyaml>=5.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (6.0.2)\n",
+      "Requirement already satisfied: rfc3339-validator in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (0.1.4)\n",
+      "Requirement already satisfied: rfc3986-validator>=0.1.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (0.1.1)\n",
+      "Requirement already satisfied: fqdn in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (1.5.1)\n",
+      "Requirement already satisfied: isoduration in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (20.11.0)\n",
+      "Requirement already satisfied: jsonpointer>1.13 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (3.0.0)\n",
+      "Requirement already satisfied: rfc3987-syntax>=1.1.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (1.1.0)\n",
+      "Requirement already satisfied: uri-template in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (1.3.0)\n",
+      "Requirement already satisfied: webcolors>=24.6.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (24.11.1)\n",
+      "Requirement already satisfied: beautifulsoup4 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (4.13.4)\n",
+      "Requirement already satisfied: bleach!=5.0.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from bleach[css]!=5.0.0->nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (6.2.0)\n",
+      "Requirement already satisfied: defusedxml in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (0.7.1)\n",
+      "Requirement already satisfied: jupyterlab-pygments in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (0.3.0)\n",
+      "Requirement already satisfied: mistune<4,>=2.0.3 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (3.1.3)\n",
+      "Requirement already satisfied: nbclient>=0.5.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (0.10.2)\n",
+      "Requirement already satisfied: pandocfilters>=1.4.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (1.5.1)\n",
+      "Requirement already satisfied: webencodings in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from bleach!=5.0.0->bleach[css]!=5.0.0->nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (0.5.1)\n",
+      "Requirement already satisfied: tinycss2<1.5,>=1.1.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from bleach[css]!=5.0.0->nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (1.4.0)\n",
+      "Requirement already satisfied: fastjsonschema>=2.15 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from nbformat>=5.3.0->jupyter-server<3,>=2.4.0->notebook) (2.21.2)\n",
+      "Requirement already satisfied: ptyprocess>=0.5 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from pexpect>4.3->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.7.0)\n",
+      "Requirement already satisfied: lark>=1.2.2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from rfc3987-syntax>=1.1.0->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (1.2.2)\n",
+      "Requirement already satisfied: cffi>=1.0.1 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->notebook) (1.17.1)\n",
+      "Requirement already satisfied: pycparser in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from cffi>=1.0.1->argon2-cffi-bindings->argon2-cffi>=21.1->jupyter-server<3,>=2.4.0->notebook) (2.22)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from beautifulsoup4->nbconvert>=6.4.4->jupyter-server<3,>=2.4.0->notebook) (2.7)\n",
+      "Requirement already satisfied: arrow>=0.15.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from isoduration->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (1.3.0)\n",
+      "Requirement already satisfied: types-python-dateutil>=2.8.10 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from arrow>=0.15.0->isoduration->jsonschema[format-nongpl]>=4.18.0->jupyter-events>=0.11.0->jupyter-server<3,>=2.4.0->notebook) (2.9.0.20250809)\n",
+      "Requirement already satisfied: executing>=1.2.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from stack_data->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (2.2.0)\n",
+      "Requirement already satisfied: asttokens>=2.1.0 in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from stack_data->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (3.0.0)\n",
+      "Requirement already satisfied: pure-eval in /Users/OwenLittlejohns/opt/miniconda3/envs/vi-harmony/lib/python3.12/site-packages (from stack_data->ipython>=7.23.1->ipykernel!=6.30.0,>=6.5.0->jupyterlab<4.5,>=4.4.5->notebook) (0.2.3)\n",
+      "Downloading pyproj-3.7.2-cp312-cp312-macosx_14_0_arm64.whl (4.6 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m4.6/4.6 MB\u001b[0m \u001b[31m23.3 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m eta \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: pyproj\n",
+      "Successfully installed pyproj-3.7.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install notebook harmony-py pyproj numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "import numpy as np\n",
+    "from harmony import BBox, Client, Collection, Environment, Request\n",
+    "from pyproj import CRS, Transformer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below is a lightly edited version of the one provided from [here](https://github.com/ICESAT-2HackWeek/icesat2-cookbook/blob/main/notebooks/draft/workflows/greenland_dhdt/dhdt_40km_tile.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.25 ms, sys: 415 μs, total: 1.66 ms\n",
+      "Wall time: 1.2 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# Bounding box information:\n",
+    "\n",
+    "# Lower left corner:\n",
+    "xy0 = [0., -3.0e6]\n",
+    "\n",
+    "# CRS of source data:\n",
+    "crs = 3413\n",
+    "\n",
+    "# Padding width\n",
+    "width = 4.e4\n",
+    "\n",
+    "pad = np.array([-width / 2, width / 2])\n",
+    "\n",
+    "# Generate bounding box in projected metres:\n",
+    "bbox_projected = [xy0[0] + pad[[0, 1, 1, 0, 0]], xy0[1] + pad[[0, 0, 1, 1, 0]]]\n",
+    "\n",
+    "# Generate a clipping polygon in lat/lon CRS\n",
+    "polygon_geographic = Transformer.from_crs(CRS(crs), CRS(4326)).transform(*bbox_projected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate variable list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 24 μs, sys: 0 ns, total: 24 μs\n",
+      "Wall time: 26.9 μs\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "base_variable_names = [\n",
+    "    'land_ice_segments/h_li',\n",
+    "    'land_ice_segments/fit_statistics/n_fit_photons',\n",
+    "    'land_ice_segments/fit_statistics/dh_fit_dx',\n",
+    "    'land_ice_segments/fit_statistics/w_surface_window_final',\n",
+    "    'land_ice_segments/atl06_quality_summary',\n",
+    "    'land_ice_segments/geophysical/bsnow_conf',\n",
+    "    'land_ice_segments/h_li_sigma',\n",
+    "    'land_ice_segments/geophysical/r_eff',\n",
+    "    'land_ice_segments/geophysical/bsnow_h',\n",
+    "    'land_ice_segments/geophysical/tide_ocean',\n",
+    "    'land_ice_segments/ground_track/x_atc',\n",
+    "    'land_ice_segments/fit_statistics/h_robust_sprd',\n",
+    "    'land_ice_segments/segment_id',\n",
+    "    'land_ice_segments/ground_track/y_atc',\n",
+    "    'land_ice_segments/ground_track/seg_azimuth',\n",
+    "    'land_ice_segments/sigma_geo_h',\n",
+    "    'land_ice_segments/delta_time',\n",
+    "    'land_ice_segments/latitude',\n",
+    "    'land_ice_segments/longitude',\n",
+    "]\n",
+    "\n",
+    "ground_tracks = ['gt1l', 'gt1r', 'gt2l', 'gt2r', 'gt3l', 'gt3r']\n",
+    "\n",
+    "all_variables = [\n",
+    "    '/'.join([ground_track, base_variable_name])\n",
+    "    for ground_track in ground_tracks\n",
+    "    for base_variable_name in base_variable_names\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the Harmony request to process the data\n",
+    "\n",
+    "Note - NSIDC has not populated UMM-Var records, so this does not do variable subsetting. (The option for that is commented out)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The history saving thread hit an unexpected error (OperationalError('attempt to write a readonly database')).History will not be written to the database.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " [ Processing: 100% ] |###################################################| [|]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.44 s, sys: 679 ms, total: 2.12 s\n",
+      "Wall time: 3min 13s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "atl03_concept_id = 'C2670138092-NSIDC_CPRD'\n",
+    "start_datetime = datetime.fromisoformat('2018-10-13T00:00:00Z')\n",
+    "stop_datetime = datetime.fromisoformat('2025-10-13T00:00:00Z')\n",
+    "\n",
+    "harmony_client = Client(env=Environment.PROD)\n",
+    "\n",
+    "harmony_request = Request(\n",
+    "    collection=Collection(id=atl03_concept_id),\n",
+    "    spatial=BBox(\n",
+    "        w=min(polygon_geographic[1]),\n",
+    "        s=min(polygon_geographic[0]),\n",
+    "        e=max(polygon_geographic[1]),\n",
+    "        n=max(polygon_geographic[0]),\n",
+    "    ),\n",
+    "    temporal={'start': start_datetime, 'stop': stop_datetime},\n",
+    "    # variables=all_variables,\n",
+    "    max_results=5,  # To allow the job to complete. Really there are 214 matching granules\n",
+    ")\n",
+    "\n",
+    "harmony_job_id = harmony_client.submit(harmony_request)\n",
+    "harmony_client.wait_for_processing(harmony_job_id, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quick stats:\n",
+    "\n",
+    "Individual granule takes about 10 - 15 seconds to process - 2 - 5 seconds to download granule to Harmony Docker container. The rest of the time is processing and staging the output. (The processing will be quicker with variable subsetting, as less of the file is spatially subsetted and staged to the output location)\n",
+    "\n",
+    "Wall time of 7 minutes 23 seconds: 7 granules processed. 3 had no data. Maybe one more in progress. Rest not started.\n",
+    "\n",
+    "Second run (max results = 5):\n",
+    "\n",
+    "```\n",
+    "CPU times: user 1.44 s, sys: 679 ms, total: 2.12 s\n",
+    "Wall time: 3min 13s\n",
+    "```\n",
+    "\n",
+    "But there's a possibility that Harmony has cached some of the output from the first time, and so was quicker."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download all the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "107559860_ATL06_20181014064703_02390105_006_02_subsetted.h5\n",
+      "107559861_ATL06_20181112052321_06810105_006_02_subsetted.h5\n",
+      "107559862_ATL06_20181211035908_11230105_006_02_subsetted.h5\n",
+      "107559863_ATL06_20190103142422_00940203_006_02_subsetted.h5\n",
+      "['107559860_ATL06_20181014064703_02390105_006_02_subsetted.h5', '107559861_ATL06_20181112052321_06810105_006_02_subsetted.h5', '107559862_ATL06_20181211035908_11230105_006_02_subsetted.h5', '107559863_ATL06_20190103142422_00940203_006_02_subsetted.h5']\n",
+      "CPU times: user 120 ms, sys: 164 ms, total: 284 ms\n",
+      "Wall time: 40.7 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "downloaded_files = [\n",
+    "    file_future.result()\n",
+    "    for file_future in harmony_client.download_all(harmony_job_id, overwrite=True)\n",
+    "]\n",
+    "\n",
+    "print(downloaded_files)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quick stats:\n",
+    "\n",
+    "```\n",
+    "CPU times: user 120 ms, sys: 164 ms, total: 284 ms\n",
+    "Wall time: 40.7 s\n",
+    "```\n",
+    "\n",
+    "Approx. 10 seconds per download. Although, that is for outputs with all variables. So likely can gain a factor of 2 or 3 with variable subsetting."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
The Harmony workflow is imperfect:

* ATL06 does not have UMM-Var metadata, so variable subsetting is not applied.
* The runtime is really slow (the job isn't parallelised well), so I've stuck in a `max_results=5` to get it to complete in a reasonable time. (Really there are 214 results)

General takeaway - this is _much_ slower than the benchmark of 30 seconds. There are potential gains (Harmony scaling out more, and having the service not download the granule locally to process), but most of those aren't short-term wins.